### PR TITLE
refactor: change default title (to avoid BS acronym)

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -19,7 +19,9 @@ export default createConfig({
   basePath,
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET,
-  title: process.env.NEXT_PUBLIC_SANITY_PROJECT_TITLE || 'Blog Studio',
+  title:
+    process.env.NEXT_PUBLIC_SANITY_PROJECT_TITLE ||
+    'Next.js Blog with Sanity.io',
   schema: {
     // If you want more content types, you can add them to this array
     types: [settingsType, postType, authorType],


### PR DESCRIPTION
This change configures `Next.js Blog with Sanity.io` as the default title of the Studio. The reason for this change is to avoid the `BS` acronym on the login screen.