### PR TITLE
Update messaging on intro component

### DIFF
--- a/components/intro-template.tsx
+++ b/components/intro-template.tsx
@@ -6,12 +6,15 @@ import introTemplateImg from '../images/introTemplateImg.png'
 export default function IntroTemplate() {
   const [studioURL, setStudioURL] = useState(null)
   const [createPostURL, setCreatePostURL] = useState(null)
-  const hasEnvVars =
+  const [isLocalHost, setIsLocalhost] = useState(false)
+
+  const hasEnvFile = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
+  const hasRepoEnvVars =
     process.env.NEXT_PUBLIC_VERCEL_GIT_PROVIDER &&
     process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER &&
     process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG
   const repoURL = `https://${process.env.NEXT_PUBLIC_VERCEL_GIT_PROVIDER}.com/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER}/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG}`
-  const removeBlockURL = hasEnvVars
+  const removeBlockURL = hasRepoEnvVars
     ? `https://${process.env.NEXT_PUBLIC_VERCEL_GIT_PROVIDER}.com/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER}/${process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_SLUG}/blob/main/README.md#how-can-i-remove-the-next-steps-block-from-my-blog`
     : `https://github.com/sanity-io/nextjs-blog-cms-sanity-v3#how-can-i-remove-the-next-steps-block-from-my-blog`
 
@@ -21,6 +24,7 @@ export default function IntroTemplate() {
       setCreatePostURL(
         `${window.location.href}/studio/intent/create/template=post;type=post/`
       )
+      setIsLocalhost(window.location.hostname === 'localhost')
     }
   }, [])
 
@@ -38,7 +42,7 @@ export default function IntroTemplate() {
           Next steps
         </h2>
 
-        {!hasEnvVars && (
+        {!hasEnvFile && (
           <div
             className="mb-6 rounded-lg bg-yellow-100 p-4 text-sm text-yellow-700"
             role="alert"
@@ -89,7 +93,15 @@ export default function IntroTemplate() {
                   Modify and deploy the project
                 </div>
 
-                {hasEnvVars ? (
+                {isLocalHost ? (
+                  <div className="text-xs text-gray-700">
+                    Start editing your content structure by changing the post
+                    schema in
+                    <div className="w-fit bg-slate-200 px-2	">
+                      <pre>schemas/post.ts</pre>
+                    </div>
+                  </div>
+                ) : (
                   <>
                     <div className="text-xs text-gray-700">
                       Your code can be found at
@@ -107,16 +119,6 @@ export default function IntroTemplate() {
                       </a>
                     </div>
                   </>
-                ) : (
-                  <div className="text-xs text-gray-700">
-                    In order to continue with this step, you need to
-                    <LinkAttribute
-                      href={
-                        'https://github.com/sanity-io/nextjs-blog-cms-sanity-v3#step-2-set-up-the-project-locally'
-                      }
-                      text={`set up the project locally`}
-                    />
-                  </div>
                 )}
               </div>
             }

--- a/components/intro-template.tsx
+++ b/components/intro-template.tsx
@@ -97,7 +97,7 @@ export default function IntroTemplate() {
                   <div className="text-xs text-gray-700">
                     Start editing your content structure by changing the post
                     schema in
-                    <div className="w-fit bg-slate-200 px-2	">
+                    <div className="w-fit bg-slate-200 px-2">
                       <pre>schemas/post.ts</pre>
                     </div>
                   </div>

--- a/schemas/post.ts
+++ b/schemas/post.ts
@@ -3,6 +3,18 @@ import { defineType } from 'sanity'
 
 import authorType from './author'
 
+/**
+ * This file is the schema definition for a post.
+ *
+ * Here you'll be able to edit the different fields that appear when you 
+ * create or edit a post in the studio.
+ * 
+ * Here you can see the different schema types that are available:
+
+  https://www.sanity.io/docs/schema-types
+
+ */
+
 export default defineType({
   name: 'post',
   title: 'Post',


### PR DESCRIPTION
- Changed step 2. to have a more active direction once users are running the code locally (because it means they’ve already cloned the repo, so the previous instruction wasn’t helpful)
- The yellow card will only appear if detect that one of the properties that step 1 (pulling vercel envs) sets up, isn’t there
- Because we are now leading people to the post in two places (both in step 1 and step 2), I added a small docs link and explanation 

![image](https://user-images.githubusercontent.com/6951139/197732774-51574885-2211-448a-9cd9-d6bbebfa723f.png)