### PR TITLE
fix: refactor timing when the sanity client is created

### DIFF
--- a/lib/sanity.server.tsx
+++ b/lib/sanity.server.tsx
@@ -7,18 +7,18 @@ import { createClient } from 'next-sanity'
 
 import { sanityConfig } from './config'
 
-export const sanityClient = createClient(sanityConfig)
-
-export const previewClient = createClient({
-  ...sanityConfig,
-  useCdn: false,
-  // Fallback to using the WRITE token until https://www.sanity.io/docs/vercel-integration starts shipping a READ token.
-  // As this client only exists on the server and the token is never shared with the browser, we don't risk escalating permissions to untrustworthy users
-  token:
-    process.env.SANITY_API_READ_TOKEN || process.env.SANITY_API_WRITE_TOKEN,
-})
-
-export const getClient = (preview) => (preview ? previewClient : sanityClient)
+export const getClient = (preview) =>
+  preview
+    ? createClient({
+        ...sanityConfig,
+        useCdn: false,
+        // Fallback to using the WRITE token until https://www.sanity.io/docs/vercel-integration starts shipping a READ token.
+        // As this client only exists on the server and the token is never shared with the browser, we don't risk escalating permissions to untrustworthy users
+        token:
+          process.env.SANITY_API_READ_TOKEN ||
+          process.env.SANITY_API_WRITE_TOKEN,
+      })
+    : createClient(sanityConfig)
 
 export function overlayDrafts(docs) {
   const documents = docs || []

--- a/pages/api/preview.tsx
+++ b/pages/api/preview.tsx
@@ -1,5 +1,5 @@
 import { postBySlugQuery } from '../../lib/queries'
-import { previewClient } from '../../lib/sanity.server'
+import { getClient } from '../../lib/sanity.server'
 
 function redirectToPreview(res, Location) {
   // Enable Preview Mode by setting the cookies
@@ -21,7 +21,7 @@ export default async function preview(req, res) {
   }
 
   // Check if the post with the given `slug` exists
-  const post = await previewClient.fetch(postBySlugQuery, {
+  const post = await getClient(true).fetch(postBySlugQuery, {
     slug: req.query.slug,
   })
 

--- a/pages/api/revalidate.tsx
+++ b/pages/api/revalidate.tsx
@@ -26,7 +26,7 @@
 
 import { isValidSignature, SIGNATURE_HEADER_NAME } from '@sanity/webhook'
 
-import { sanityClient } from '../../lib/sanity.server'
+import { getClient } from '../../lib/sanity.server'
 
 // Next.js will by default parse the body, which can lead to invalid signatures
 export const config = {
@@ -91,7 +91,7 @@ export default async function revalidate(req, res) {
   }
 
   log(`Querying post slug for _id '${id}', type '${_type}' ..`)
-  const slug = await sanityClient.fetch(getQueryForType(_type), { id })
+  const slug = await getClient(false).fetch(getQueryForType(_type), { id })
   const slugs = (Array.isArray(slug) ? slug : [slug]).map(
     (_slug) => `/posts/${_slug}`
   )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -49,12 +49,21 @@ export default function Index({
 }
 
 export async function getStaticProps({ preview = false }) {
-  const allPosts = overlayDrafts(await getClient(preview).fetch(indexQuery))
-  const blogSettings = await getClient(preview).fetch(settingsQuery)
+  /* check if the project id has been defined by fetching the vercel envs */
+  if (process.env.NEXT_PUBLIC_SANITY_PROJECT_ID) {
+    const allPosts = overlayDrafts(await getClient(preview).fetch(indexQuery))
+    const blogSettings = await getClient(preview).fetch(settingsQuery)
 
+    return {
+      props: { allPosts, preview, blogSettings },
+      // If webhooks isn't setup then attempt to re-generate in 1 minute intervals
+      revalidate: process.env.SANITY_REVALIDATE_SECRET ? undefined : 60,
+    }
+  }
+
+  /* when the client isn't set up */
   return {
-    props: { allPosts, preview, blogSettings },
-    // If webhooks isn't setup then attempt to re-generate in 1 minute intervals
-    revalidate: process.env.SANITY_REVALIDATE_SECRET ? undefined : 60,
+    props: {},
+    revalidate: undefined,
   }
 }

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -12,7 +12,7 @@ import PostTitle from '../../components/post-title'
 import SectionSeparator from '../../components/section-separator'
 import { postQuery, postSlugsQuery, settingsQuery } from '../../lib/queries'
 import { urlForImage, usePreviewSubscription } from '../../lib/sanity'
-import { getClient, overlayDrafts, sanityClient } from '../../lib/sanity.server'
+import { getClient, overlayDrafts } from '../../lib/sanity.server'
 import { PostProps } from '../../types'
 
 interface Props {
@@ -99,7 +99,7 @@ export async function getStaticProps({ params, preview = false }) {
 }
 
 export async function getStaticPaths() {
-  const paths = await sanityClient.fetch(postSlugsQuery)
+  const paths = await getClient(false).fetch(postSlugsQuery)
   return {
     paths: paths.map((slug) => ({ params: { slug } })),
     fallback: true,


### PR DESCRIPTION
When creating a project from the deploy button, you would get this error when you first loaded the blog. This was because the client was being created too early (and without the needed vercel envs, which is a step that many people while trying this for the first time might)

![image](https://user-images.githubusercontent.com/6951139/197806823-c66de71a-8825-468c-9541-a39147e24dc6.png)
