### PR TITLE
fix: turn swcMinify back on

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
-  // @TODO figure out why the swc minifier breaks preview mode
-  swcMinify: false,
-
   images: {
     remotePatterns: [
       { hostname: 'cdn.sanity.io' },


### PR DESCRIPTION
`swcMinify` is currently breaking preview mode in the "live-as-you-type" flow.

The console error is [when opening preview mode is](https://nextjs-blog-cms-sanity-v3-5emh7bly1.sanity.build/studio/desk/post;46f04857-2785-493c-bd63-be8fb35a9130%7C%2Cview%3Dpreview):
```js
728cfa9a.c8505576270af4de.js:1 Uncaught (in promise) ReferenceError: equality is not defined
    at != (728cfa9a.c8505576270af4de.js:1:40514)
    at 728cfa9a.c8505576270af4de.js:1:45366
    at 728cfa9a.c8505576270af4de.js:1:2047
    at Object.next (728cfa9a.c8505576270af4de.js:1:2152)
    at i (728cfa9a.c8505576270af4de.js:1:899)
```

It's unclear if the root cause is something in how `next-sanity`, `@sanity/groq-store`, `@sanity/eventsource`, `groq-js` or in the `swc` minifier itself.

This draft PR is to aid testing if possible dependency updates might resolve the problem in the time between now, and when we have time to properly investigate why it's breaking.