### PR TITLE
fix: `swcMinify` no longer breaks `FieldPresenceWithOverlay`

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const config = {
-  // @TODO turn swcMinify back on once the agressive dead code elimination bug that casues
-  // `ReferenceError: FieldPresenceWithOverlay is not defined` is fixed
-  swcMinify: false,
   experimental: {
     appDir: true,
   },


### PR DESCRIPTION
```bash
ReferenceError: FieldPresenceWithOverlay is not defined
    at http://localhost:3000/_next/static/chunks/5082709c-8d091cf07e04ba87.js:1:409183
    at ak (http://localhost:3000/_next/static/chunks/framework-36098b990598bc0c.js:9:60919)
    at ui (http://localhost:3000/_next/static/chunks/framework-36098b990598bc0c.js:9:71230)
    at i (http://localhost:3000/_next/static/chunks/framework-36098b990598bc0c.js:9:121562)
    at oD (http://localhost:3000/_next/static/chunks/framework-36098b990598bc0c.js:9:99116)
    at http://localhost:3000/_next/static/chunks/framework-36098b990598bc0c.js:9:98983
    at oO (http://localhost:3000/_next/static/chunks/framework-36098b990598bc0c.js:9:98990)
    at oE (http://localhost:3000/_next/static/chunks/framework-36098b990598bc0c.js:9:95742)
    at oP (http://localhost:3000/_next/static/chunks/framework-36098b990598bc0c.js:9:96131)
    at r8 (http://localhost:3000/_next/static/chunks/framework-36098b990598bc0c.js:9:44780)
```