### PR TITLE
Revert "fix: `swcMinify` no longer breaks `FieldPresenceWithOverlay`"

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const config = {
+  // @TODO turn swcMinify back on once the agressive dead code elimination bug that casues
+  // `ReferenceError: FieldPresenceWithOverlay is not defined` is fixed
+  swcMinify: false,
   experimental: {
     appDir: true,
   },


### PR DESCRIPTION
Reverts sanity-io/nextjs-blog-cms-sanity-v3#92