### PR TITLE
chore: return null from alert banner if no preview

### DIFF
--- a/components/AlertBanner.tsx
+++ b/components/AlertBanner.tsx
@@ -8,7 +8,7 @@ export default function Alert({
   preview?: boolean
   loading?: boolean
 }) {
-  if (!preview) return
+  if (!preview) return null
 
   return (
     <div className="border-b border-accent-7 bg-accent-7 text-white">


### PR DESCRIPTION
This was giving me a type error of 
```
'AlertBanner' cannot be used as a JSX component.
  Its return type 'Element | undefined' is not a valid JSX element.
    Type 'undefined' is not assignable to type 'Element | null'.ts(2786)
```

The solution is to either `return null` or `return <></>` 