### PR TITLE
chore: add sanity/ui as an actual dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@portabletext/react": "^2.0.0",
     "@sanity/image-url": "^1.0.1",
+    "@sanity/ui": "^1.0.12",
     "@sanity/vision": "^3.1.4",
     "@vercel/og": "^0.0.22",
     "classnames": "^2.3.2",


### PR DESCRIPTION
`@sanity/ui` is used in `plugins/previewPane/AuthorAvatarPreviewPane.tsx` but isn't installed as an actual dependency so it can cause some issues especially if you are implementing this from scratch you will get that `@sanity/ui` can't be found.