### PR TITLE
Fix Open Graph image generation on the Studio settings page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "sanity-plugin-asset-source-unsplash": "^1.0.6",
         "server-only": "^0.0.1",
         "styled-components": "^5.3.6",
-        "suspend-react": "^0.0.9"
+        "suspend-react": "^0.0.9",
+        "swr": "^2.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.26",
@@ -9233,6 +9234,20 @@
         "react": ">=17.0"
       }
     },
+    "node_modules/swr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.0.tgz",
+      "integrity": "sha512-IhUx5yPkX+Fut3h0SqZycnaNLXLXsb2ECFq0Y29cxnK7d8r7auY2JWNbCW3IX+EqXUg3rwNJFlhrw5Ye/b6k7w==",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.0"
+      },
+      "engines": {
+        "pnpm": "7"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -16872,6 +16887,14 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.0.9.tgz",
       "integrity": "sha512-668Pxy4z54fhjpnPqw6olj3vvpV03VywFNXazyNSYSTuHaRw3NJJjO5l8R49AUk5fMTkJXGVGaaVSgdaO01S3w=="
+    },
+    "swr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.0.tgz",
+      "integrity": "sha512-IhUx5yPkX+Fut3h0SqZycnaNLXLXsb2ECFq0Y29cxnK7d8r7auY2JWNbCW3IX+EqXUg3rwNJFlhrw5Ye/b6k7w==",
+      "requires": {
+        "use-sync-external-store": "^1.2.0"
+      }
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "sanity-plugin-asset-source-unsplash": "^1.0.6",
     "server-only": "^0.0.1",
     "styled-components": "^5.3.6",
-    "suspend-react": "^0.0.9"
+    "suspend-react": "^0.0.9",
+    "swr": "^2.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.26",

--- a/schemas/settings/OpenGraphPreview.tsx
+++ b/schemas/settings/OpenGraphPreview.tsx
@@ -25,26 +25,6 @@ const setupSegmenter = (_: undefined) => {
   }
 }
 
-const fontFetcher = (params: string) => {
-  const { name, style, weight, url } = JSON.parse(params)
-  return fetch(new URL(url))
-    .then((res) => res.arrayBuffer())
-    .then((arrayBuffer) => {
-      return { name, data: arrayBuffer, style, weight }
-    })
-}
-
-const useFont = (name, style, weight, url) => {
-  const { data, error, isLoading } = useSWR(
-    JSON.stringify({ name, style, weight, url }),
-    fontFetcher
-  )
-  return {
-    font: data,
-    isLoading,
-    isError: error,
-  }
-}
 // this fetcher function is highly specific, but otherwise NextJS does not "notice" we are importing a file from the public dir
 const interFetcher = () =>
   fetch('/Inter-Bold.woff')


### PR DESCRIPTION
fixes #185 

As discussed in the issue, the main problem was the use of `use()` and `cache()` which are only available in the experimental edge runtime of NextJS and only within the appDir (this is not documented but the result of my investigation).

As such we needed some client-side, component-level data fetching solution with caching, and seeing that the project is heavily Vercel-reliant, I thought it would be a good use case their SWR lib.