### PR TITLE
Change fallback false to blocking to avoid 404 error when trying to revalidate a new article

### DIFF
--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -92,6 +92,6 @@ export const getStaticPaths = async () => {
 
   return {
     paths: slugs?.map(({ slug }) => `/posts/${slug}`) || [],
-    fallback: false,
+    fallback: "blocking",
   }
 }


### PR DESCRIPTION
Based on:
https://github.com/sanity-io/nextjs-blog-cms-sanity-v3/issues/212

Fallback set to `false` messes up with the incremental static generation when a new article is created. That is due to Next.js trying to revalidate a page that is not generated, which returns 404 and aborts the revalidation process.

Fallback `false` only generates pages during build time. Fallback `blocking` generates pages at build time, and when it exists in the CMS, but has not been yet generated, during a first request to that page, the page gets generated.