### PR TITLE
fix: typo in web manifest

### DIFF
--- a/public/favicon/browserconfig.xml
+++ b/public/favicon/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/favicons/mstile-150x150.png"/>
+            <square150x150logo src="/favicon/mstile-150x150.png"/>
             <TileColor>#000000</TileColor>
         </tile>
     </msapplication>

--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -3,12 +3,12 @@
   "short_name": "Next.js",
   "icons": [
     {
-      "src": "/favicons/android-chrome-192x192.png",
+      "src": "/favicon/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/favicons/android-chrome-512x512.png",
+      "src": "/favicon/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
As seen in the changes the manifest and the browserconfig accidentally uses the plural of `favicons` in the path instead of the singular `favicon`